### PR TITLE
Dockerfile: Safely remove autoinstalled dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY start.go /
 RUN apt-get -y update \
 && apt-get install -y golang-go \
 && go build -o /start /start.go \
-&& apt-get remove --purge -y golang-go $(apt-mark showauto) \
+&& apt-get remove --purge -y golang-go \
+&& apt-get autoremove --purge -y \
 && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/start"]


### PR DESCRIPTION
Before, the Dockerfile tried to uninstall _all_ automatically installed
packages. However, removing `golang-go` only makes some of those
dependencies safe to remove. This commit modifies the Dockerfile to use
the `autoremove` command instead so that we don't attempt to remove
dependencies that are in still use.