### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/redis.js
+++ b/redis.js
@@ -9,7 +9,9 @@ const image = 'keldaio/redis';
  * @return {Container} The Redis master container.
  */
 function createMaster(auth) {
-  return new Container('redis-master', image, {
+  return new Container({
+    name: 'redis-master',
+    image,
     command: ['run'],
     env: {
       ROLE: 'master',
@@ -29,7 +31,9 @@ function createWorkers(n, auth, master) {
   const workers = [];
   for (let i = 0; i < n; i += 1) {
     workers.push(
-      new Container('redis-wk', image, {
+      new Container({
+        name: 'redis-wk',
+        image,
         command: ['run'],
         env: {
           ROLE: 'worker',

--- a/redisExample.js
+++ b/redisExample.js
@@ -9,5 +9,8 @@ const rds = new Redis(nWorker, 'AUTH_PASSWORD');
 
 const baseMachine = new Machine({ provider: 'Amazon' });
 
-const infra = new Infrastructure(baseMachine, baseMachine.replicate(nWorker));
+const infra = new Infrastructure({
+  masters: baseMachine,
+  workers: baseMachine.replicate(nWorker),
+});
 rds.deploy(infra);


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.